### PR TITLE
Fix express

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,15 @@
 const mongoose = require('mongoose');
 const app = require('./src/app');
 
-mongoose.connect('mongodb://mongo:27017/covid19-restaurants', {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-});
+mongoose
+  .connect('mongodb://mongo:27017/covid19-restaurants', {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  })
+  .catch((err) => {
+    // eslint-disable-next-line no-console
+    console.log(err);
+  });
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/index.js
+++ b/index.js
@@ -1,19 +1,13 @@
 const mongoose = require('mongoose');
 const app = require('./src/app');
 
-mongoose
-  .connect('mongodb://mongo:27017/covid19-restaurants', {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-  })
-  .then(() => {
-    console.log('MongoDB is connected');
-  })
-  .catch((err) => {
-    console.log(`${err.message}`);
-  });
+mongoose.connect('mongodb://mongo:27017/covid19-restaurants', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
 
-app.listen(3000, () => {
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
   // eslint-disable-next-line no-console
-  console.log(`App listening on port 3000`);
+  console.log(`App listening on port ${PORT}`);
 });


### PR DESCRIPTION
app now listens on port 3000 if there is no .env provided, or an alternate port that can be provided in an .env variable. The server will still time out eventually, need to double check the connection string for the database, as it doesn't seem to connect.

The following was causing it to hang:

  .then(() => {
    console.log('MongoDB is connected');
  })

the reason is that the above hangs is that database never connects to the data base with the following lines
mongoose
  .connect('mongodb://mongo:27017/covid19-restaurants', {
    useNewUrlParser: true,
    useUnifiedTopology: true,
  })

The connection string needs checking, it may be that we need to has password credentials similar to below:
E.g: DATABASE_CONN=mongodb://username:password@ds117960.mlab.com:17960/surreal-estate

This should definitely only be added to the project using a .env file and called in the project similar to below:
mongoose.connect(process.env.DATABASE_CONN, { useNewUrlParser: true, useUnifiedTopology: true });

Could still try Docker, but the current Docker compose file seems to go on a infinite loop of trying to access mongo.
