### PR TITLE
Dev justin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7700,6 +7700,19 @@
         }
       }
     },
+    "swagger-ui-dist": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.31.1.tgz",
+      "integrity": "sha512-+IuIxXX8grZcDVLaC12WCGy62iHJ2v8kTptU4H4EgY/ue6tKeMu/jzIAs+pLFOuYwfG4+VQ+CrC9UeHR9oNKBw=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
+      "integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5856,6 +5856,27 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
+    "method-override": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/method-override/-/method-override-3.0.0.tgz",
+      "integrity": "sha512-IJ2NNN/mSl9w3kzWB92rcdHpz+HjkxhDJWNDBqSlas+zQdP8wBiJzITPg08M/k2uVvMow7Sk41atndNtt/PHSA==",
+      "requires": {
+        "debug": "3.1.0",
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "mongoose": "^5.9.27",
     "nodemon": "^2.0.4",
     "prettier": "^2.0.5",
-    "supertest": "^4.0.2"
+    "supertest": "^4.0.2",
+    "swagger-ui-express": "^4.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.11.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
     "@babel/plugin-proposal-optional-chaining": "^7.11.0",
     "@babel/preset-env": "^7.11.0",
-    "babel-eslint": "^10.1.0",
-    "body-parser": "^1.19.0"
+    "babel-eslint": "^10.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "express": "^4.17.1",
     "express-restify-mongoose": "^6.1.2",
     "jest": "^26.2.2",
+    "method-override": "^3.0.0",
     "mongoose": "^5.9.27",
     "nodemon": "^2.0.4",
     "prettier": "^2.0.5",

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const cors = require('cors');
-const bodyParser = require('body-parser');
 const restify = require('express-restify-mongoose');
 const restaurantModel = require('./models/restaurants');
 const favouritesModel = require('./models/favourites');
@@ -10,7 +9,6 @@ const router = express.Router();
 
 app.use(cors());
 app.use(express.json());
-app.use(bodyParser.json());
 app.use(router);
 
 //endpoint === /api/v1/restaurant for GET, POST, PUT and DELETE

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,8 @@ const methodOverride = require('method-override');
 const restify = require('express-restify-mongoose');
 const restaurantModel = require('./models/restaurants');
 const favouritesModel = require('./models/favourites');
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./swagger.json');
 
 const app = express();
 const router = express.Router();
@@ -18,5 +20,7 @@ restify.serve(router, restaurantModel);
 
 //endpoint === /api/v1/favourite for GET, POST, PUT and DELETE
 restify.serve(router, favouritesModel);
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 module.exports = app;

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const methodOverride = require('method-override');
 const restify = require('express-restify-mongoose');
 const restaurantModel = require('./models/restaurants');
 const favouritesModel = require('./models/favourites');
@@ -9,6 +10,7 @@ const router = express.Router();
 
 app.use(cors());
 app.use(express.json());
+app.use(methodOverride());
 app.use(router);
 
 //endpoint === /api/v1/restaurant for GET, POST, PUT and DELETE

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1,0 +1,328 @@
+{
+    "swagger": "2.0",
+    "info": {
+       "description": "API to access database of COVID safe restaurants",
+       "version": "0.1",
+       "title": "covid-safe-restaurants"
+    },
+    "host": "localhost:4000",
+    "basePath": "/api/v1",
+    "tags": [
+       {
+          "name": "Restaurants",
+          "description": "API endpoints for managing PropertyListings"
+       },
+       {
+          "name": "Favourites",
+          "description": "API endpoints for managing Favourites"
+       }
+    ],
+    "schemes": [
+       "http"
+    ],
+    "consumes": [
+       "application/json"
+    ],
+    "produces": [
+       "application/json"
+    ],
+    "paths": {
+       "/api/v1/favourite/": {
+          "get": {
+             "tags": [
+                "Favourites"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Favourite"
+                   }
+                }
+             }
+          }
+       },
+       "/api/v1/favourite/:id": {
+          "get": {
+             "tags": [
+                "Favourites"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Favourite"
+                   }
+                }
+             }
+          },
+          "post": {
+             "tags": [
+                "Favourites"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Favourite"
+                   }
+                }
+             }
+          },
+          "put": {
+             "tags": [
+                "Favourites"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Favourite"
+                   }
+                }
+             }
+          },
+          "delete": {
+             "tags": [
+                "Favourites"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Favourite"
+                   }
+                }
+             }
+          }
+       },
+       "/api/v1/restaurant/": {
+          "get": {
+             "tags": [
+                "Restaurants"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector"
+                }
+             }
+          },
+          "post": {
+             "tags": [
+                "Restaurants"
+             ],
+             "consumes": [
+                "application/json"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [
+                {
+                   "in": "body",
+                   "name": "body",
+                   "required": false,
+                   "schema": {
+                      "$ref": "#/definitions/Restaurant"
+                   },
+                   "x-examples": {
+                      "application/json": "{\n  \"name\": \"Test Restaurant Truthy\",\n  \"type\": \"Test\",\n  \"description\": \"This is a test with all Truthy values\",\n  \"onDeliveroo\": \"true\",\n  \"onJustEat\": \"true\",\n  \"onUberEats\": \"true\",\n  \"isOpen\": \"true\",\n  \"openingTimes\": \"9:00am - 10:00pm, Mon-Sun\",\n  \"eatOutToHelpOut\": \"50% off meal, up to £10 per person\",\n  \"outsideSeating\": \"true\",\n  \"website\": \"https://www.example.com\",\n  \"instagram\": \"\",\n  \"phoneNumber\": \"0123456789\",\n  \"picture\": \"https://imgfile\"\n}"
+                   }
+                }
+             ],
+             "responses": {
+                "201": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Restaurant"
+                   }
+                }
+             }
+          }
+       },
+       "/api/v1/restaurant/:id": {
+          "get": {
+             "tags": [
+                "Restaurants"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Restaurant"
+                   }
+                }
+             }
+          },
+          "put": {
+             "tags": [
+                "Restaurants"
+             ],
+             "consumes": [
+                "application/json"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [
+                {
+                   "in": "body",
+                   "name": "body",
+                   "required": false,
+                   "schema": {
+                      "$ref": "#/definitions/Restaurant"
+                   },
+                   "x-examples": {
+                      "application/json": "{\n  \"name\": \"Test Restaurant Truthy\",\n  \"type\": \"Test\",\n  \"description\": \"This is a test with all Truthy values\",\n  \"onDeliveroo\": \"true\",\n  \"onJustEat\": \"true\",\n  \"onUberEats\": \"true\",\n  \"isOpen\": \"false\",\n  \"openingTimes\": \"9:00am - 10:00pm, Mon-Sun\",\n  \"eatOutToHelpOut\": \"50% off meal, up to £10 per person\",\n  \"outsideSeating\": \"true\",\n  \"website\": \"https://www.example.com\",\n  \"instagram\": \"\",\n  \"phoneNumber\": \"0123456789\",\n  \"picture\": \"https://imgfileChanged\"\n}"
+                   }
+                }
+             ],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Restaurant"
+                   }
+                }
+             }
+          },
+          "delete": {
+             "tags": [
+                "Restaurants"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "204": {
+                   "description": "Definition generated from Swagger Inspector"
+                }
+             }
+          }
+       },
+       "/api/v1/restaurant/count": {
+          "get": {
+             "tags": [
+                "Restaurants"
+             ],
+             "produces": [
+                "application/json"
+             ],
+             "parameters": [],
+             "responses": {
+                "200": {
+                   "description": "Definition generated from Swagger Inspector",
+                   "schema": {
+                      "$ref": "#/definitions/Count"
+                   }
+                }
+             }
+          }
+       }
+    },
+    "definitions": {
+       "Restaurant": {
+          "properties": {
+             "name": {
+                "type": "string"
+             },
+             "type": {
+                "type": "string"
+             },
+             "description": {
+                "type": "string"
+             },
+             "onDeliveroo": {
+                "type": "string"
+             },
+             "onJustEat": {
+                "type": "string"
+             },
+             "onUberEats": {
+                "type": "string"
+             },
+             "isOpen": {
+                "type": "string"
+             },
+             "openingTimes": {
+                "type": "string"
+             },
+             "eatOutToHelpOut": {
+                "type": "string"
+             },
+             "outsideSeating": {
+                "type": "string"
+             },
+             "website": {
+                "type": "string"
+             },
+             "instagram": {
+                "type": "string"
+             },
+             "phoneNumber": {
+                "type": "string"
+             },
+             "picture": {
+                "type": "string"
+             }
+          }
+       },
+       "Count": {
+          "properties": {
+             "count": {
+                "type": "integer",
+                "format": "int32"
+             }
+          }
+       },
+       "Favourite": {
+          "required": [
+             "_id",
+             "restaurant",
+             "fbUserId"
+          ],
+          "properties": {
+             "_id": {
+                "type": "string",
+                "uniqueItems": true
+             },
+             "propertyListing": {
+                "type": "string",
+                "description": "Property ID"
+             },
+             "fbUserId": {
+                "type": "string"
+             }
+          }
+       }
+    }
+ }

--- a/src/swagger.yaml
+++ b/src/swagger.yaml
@@ -1,0 +1,247 @@
+swagger: '2.0'
+info:
+  description: API to access database of COVID safe restaurants
+  version: '0.1'
+  title: covid-safe-restaurants
+host: 'localhost:3000'
+basePath: /api/v1
+tags:
+  - name: Restaurants
+    description: API endpoints for managing PropertyListings
+  - name: Favourites
+    description: API endpoints for managing Favourites
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json  
+  
+paths:
+  /api/v1/favourite/:
+    get:
+      tags: 
+        - Favourites
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Favourite'
+            
+  /api/v1/favourite/:id:
+    get:
+      tags: 
+        - Favourites
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Favourite' 
+    post:
+      tags: 
+        - Favourites    
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Favourite' 
+    put:
+      tags: 
+        - Favourites    
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Favourite' 
+    delete:
+      tags: 
+        - Favourites    
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Favourite'
+            
+  /api/v1/restaurant/:
+    get:
+      tags: 
+        - Restaurants     
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector  
+    post:
+      tags: 
+        - Restaurants     
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/Restaurant' 
+          x-examples:
+            application/json: |-
+              {
+                "name": "Test Restaurant Truthy",
+                "type": "Test",
+                "description": "This is a test with all Truthy values",
+                "onDeliveroo": "true",
+                "onJustEat": "true",
+                "onUberEats": "true",
+                "isOpen": "true",
+                "openingTimes": "9:00am - 10:00pm, Mon-Sun",
+                "eatOutToHelpOut": "50% off meal, up to £10 per person",
+                "outsideSeating": "true",
+                "website": "https://www.example.com",
+                "instagram": "",
+                "phoneNumber": "0123456789",
+                "picture": "https://imgfile"
+              }
+      responses:
+        '201':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Restaurant'  
+            
+  /api/v1/restaurant/:id:
+    get:
+      tags: 
+        - Restaurants    
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Restaurant' 
+    put:
+      tags: 
+        - Restaurants     
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: body
+          name: body
+          required: false
+          schema:
+            $ref: '#/definitions/Restaurant' 
+          x-examples:
+            application/json: |-
+              {
+                "name": "Test Restaurant Truthy",
+                "type": "Test",
+                "description": "This is a test with all Truthy values",
+                "onDeliveroo": "true",
+                "onJustEat": "true",
+                "onUberEats": "true",
+                "isOpen": "false",
+                "openingTimes": "9:00am - 10:00pm, Mon-Sun",
+                "eatOutToHelpOut": "50% off meal, up to £10 per person",
+                "outsideSeating": "true",
+                "website": "https://www.example.com",
+                "instagram": "",
+                "phoneNumber": "0123456789",
+                "picture": "https://imgfileChanged"
+              }
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Restaurant' 
+    delete:
+      tags: 
+        - Restaurants     
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '204':
+          description: Definition generated from Swagger Inspector
+          
+  /api/v1/restaurant/count:
+    get:
+      tags: 
+        - Restaurants     
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        '200':
+          description: Definition generated from Swagger Inspector
+          schema:
+            $ref: '#/definitions/Count' 
+          
+definitions:
+  Restaurant:
+    properties:
+      name:
+        type: string
+      type:
+        type: string
+      description:
+        type: string
+      onDeliveroo:
+        type: string
+      onJustEat:
+        type: string
+      onUberEats:
+        type: string
+      isOpen:
+        type: string
+      openingTimes:
+        type: string
+      eatOutToHelpOut:
+        type: string
+      outsideSeating:
+        type: string
+      website:
+        type: string
+      instagram:
+        type: string
+      phoneNumber:
+        type: string
+      picture:
+        type: string
+  Count:
+    properties:
+      count:
+        type: integer
+        format: int32
+  Favourite:
+    required:
+      - _id
+      - restaurant
+      - fbUserId
+    properties:
+      _id:
+        type: string
+        uniqueItems: true
+      propertyListing:
+        type: string
+        description: Property ID
+      fbUserId:
+        type: string       


### PR DESCRIPTION
Created the API documentation for the Restaurant and Favourite endpoints. If updates need to be made these can either be done directly on the swagger.json file, or for a more user friendly way they can be done on SwaggerHUB and using YAML format - this is just a bit nicer to work with since there are no curly braces to deal with, however the swagger-ui-express package used in the api requires .json format, so the file will need to be coverted to .json if using this method. 

The API documentation should now be visible on http://localhost:4000/api-docs when running from a dev environment.