### PR TITLE
fixed a typo in the restaurant model, model referenced 'outsideSeatin…

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ const methodOverride = require('method-override');
 const restify = require('express-restify-mongoose');
 const restaurantModel = require('./models/restaurants');
 const favouritesModel = require('./models/favourites');
+const restaurantRoutes = require('./routes/restaurants');
 const swaggerUi = require('swagger-ui-express');
 const swaggerDocument = require('./swagger.json');
 
@@ -22,5 +23,7 @@ restify.serve(router, restaurantModel);
 restify.serve(router, favouritesModel);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+
+app.use('/api/v2/restaurant', restaurantRoutes);
 
 module.exports = app;

--- a/src/controllers/restaurants.js
+++ b/src/controllers/restaurants.js
@@ -11,7 +11,7 @@ exports.create = (req, res) => {
     isOpen,
     openingTimes,
     eatOutToHelpOut,
-    outsideSeating,
+    outdoorSeating,
     website,
     instagram,
     phoneNumber,
@@ -30,7 +30,7 @@ exports.create = (req, res) => {
     isOpen: isOpen,
     openingTimes: openingTimes,
     eatOutToHelpOut: eatOutToHelpOut,
-    outdoorSeating: outsideSeating,
+    outdoorSeating: outdoorSeating,
     website: website,
     instagram: instagram,
     phoneNumber: phoneNumber,
@@ -44,28 +44,24 @@ exports.create = (req, res) => {
   });
 };
 
-exports.list = (req, res) => {
+exports.listAll = (req, res) => {
+  const queryObj = {};
+
   const query = Restaurant.find();
 
-  if (req.query.name) {
-    query.where('name', new RegExp(req.query.name, 'i'));
-  } else if (req.query.type) {
-    query.where('type').equals(req.query.type);
-  } else if (req.query.onDeliveroo) {
-    query.where('onDeliveroo').equals(req.query.onDeliveroo);
-  } else if (req.query.onJustEat) {
-    query.where('onJustEat').equals(req.query.onJustEat);
-  } else if (req.query.onUberEats) {
-    query.where('onUberEats').equals(req.query.onUberEats);
-  } else if (req.query.isOpen) {
-    query.where('isOpen').equals(req.query.isOpen);
-  } else if (req.query.eatOutToHelpOut) {
-    query.where('eatOutToHelpOut').equals(req.query.eatOutToHelpOut);
-  } else if (req.query.outsideSeating) {
-    query.where('outsideSeating').equals(req.query.outsideSeating);
-  }
+  if (req.query.name) { queryObj['name'] = new RegExp(req.query.name, 'i'); } 
+  if (req.query.type) { queryObj['type'] = req.query.type; } 
+  if (req.query.onDeliveroo) { queryObj['onDeliveroo'] = req.query.onDeliveroo; } 
+  if (req.query.onJustEat) { queryObj['onJustEat'] = req.query.onJustEat; } 
+  if (req.query.onUberEats) { queryObj['onUberEats'] = req.query.onUberEats; } 
+  if (req.query.isOpen) { queryObj['isOpen'] = req.query.isOpen; }
+  if (req.query.eatOutToHelpOut) { queryObj['eatOutToHelpOut'] = req.query.eatOutToHelpOut; }
+  if (req.query.outdoorSeating) { queryObj['outdoorSeating'] = req.query.outdoorSeating; }
+  if (req.query.city) { queryObj['city'] = req.query.city; }
+  if (req.query.postcode) { queryObj['city'] = req.query.postcode; }
 
   query
+    .where(queryObj)
     .exec()
     .then((restaurants) => {
       res.status(200).json(restaurants);

--- a/src/models/restaurants.js
+++ b/src/models/restaurants.js
@@ -10,7 +10,7 @@ const restaurantSchema = new mongoose.Schema({
   isOpen: Boolean,
   openingTimes: String,
   eatOutToHelpOut: String,
-  outsideSeating: Boolean,
+  outdoorSeating: Boolean,
   website: String,
   instagram: String,
   phoneNumber: String,

--- a/src/routes/restaurants.js
+++ b/src/routes/restaurants.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const restaurantController = require('../controllers/restaurants');
+
+const router = express.Router();
+
+router
+    .route('/')
+    .post(restaurantController.create)
+    .get(restaurantController.listAll);
+
+//router
+//    .route('/:restaurantId')
+//    .get(restaurantController.listAll);
+
+module.exports = router;

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -328,7 +328,7 @@
              "eatOutToHelpOut": {
                 "type": "string"
              },
-             "outsideSeating": {
+             "outdoorSeating": {
                 "type": "string"
              },
              "website": {

--- a/src/swagger.yaml
+++ b/src/swagger.yaml
@@ -263,7 +263,7 @@ definitions:
         type: string
       eatOutToHelpOut:
         type: string
-      outsideSeating:
+      outdoorSeating:
         type: string
       website:
         type: string


### PR DESCRIPTION
…g', but the create path referenced 'outdoorSeating', the database is populated with outdoorSeating as the convention, therefore the model has been updated to reflect this. Also, this path has a new routes and controller for the tentative /api/v2/ set of endpoints, this is an initiative to move away from the express-restify-mongoose package of creating the usable endpoints which should eventually provide more control over what api endpoints are exposed, this is particularly important in regards to the DELETE routes as this can be accessed by anyone in its current state to delete the database entries.